### PR TITLE
https://github.com/jacob-meacham/serverless-plugin-bind-deployment-id/issues/10

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ci:coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {
-    "lodash": "4.17.4"
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "ava": "0.17.0",


### PR DESCRIPTION
We should update lodash, since the one this explicitly depends on has known security vulnerabilities.