### PR TITLE
Add support for replacing id in resource extensions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,12 @@ export default class BindDeploymentId {
         template.Resources = this.fixUpApiKeys(template.Resources, customStages)
       }
     }
+
+    const resourceExtensions = _.get(this.serverless.service, 'resources.extensions', null)
+    if (resourceExtensions) {
+      const variableRegex = new RegExp(_.get(this.serverless.service, 'custom.deploymentId.variableSyntax', '__deployment__'), 'g')
+      this.serverless.service.resources.extensions = this.replaceDeploymentIdReferences(resourceExtensions, deploymentId, variableRegex)
+    }
   }
 
   replaceDeploymentIdReferences(resources, deploymentId, variableRegex) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -83,6 +83,29 @@ test('bindDeploymentId#default', t => {
   })
 })
 
+test('bindDeploymentId#replacesExtensions', t => {
+  const serverless = buildServerless()
+  serverless.service.provider.compiledCloudFormationTemplate = defaultCompiledCloudFormation()
+  serverless.service.resources = {
+    extensions: {
+      __deployment__: {
+        DependsOn: [
+          'sample'
+        ]
+      }
+    }
+  }
+
+  const plugin = new BindDeploymentId(serverless, {})
+  plugin.bindDeploymentId()
+
+  t.deepEqual(serverless.service.resources.extensions.ApiGatewayDeployment1484416530047, {
+    DependsOn: [
+      'sample'
+    ]
+  })
+})
+
 test('bindDeploymentId#noCustomStages', t => {
   const serverless = buildServerless()
   serverless.service.provider.compiledCloudFormationTemplate = defaultCompiledCloudFormation()


### PR DESCRIPTION
The Serverless framework has added support for the `resources.extensions`
block, which has slightly-more-formalized merge behaviour.

This change adds support for replacing the deployment ID in the extensions
block.

Fixes #25.
Relates to serverless/serverless#6575.