### PR TITLE
Remove "serverless" as a peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,6 @@
     "eslint-plugin-import": "2.18.1",
     "eslint-plugin-node": "9.1.0"
   },
-  "peerDependencies": {
-    "serverless": ">=1.48.0"
-  },
   "ava": {
     "require": [
       "babel-register"


### PR DESCRIPTION
The peer dependency upon serverless causes an "unmet peer dependency" warning when serverless is installed, not locally, but globally.  I concede it does seem very reasonable to have serverless as a peer, and I don't know why npm doesn't look globally before issuing this warning.  Perhaps the warning disappears when listed under "dependencies"?  Nonetheless, I note that most other serverless plugins do not cite serverless as a dependency at all!?  So to assume serverless seems to be the convention.